### PR TITLE
Fix residual block

### DIFF
--- a/src/SRResNet.py
+++ b/src/SRResNet.py
@@ -16,7 +16,8 @@ class _Residual_Block(nn.Module):
         
         self.bn = bn
         self.conv1 = nn.Conv2d(in_channels=64, out_channels=64, kernel_size=3, stride=1, padding=1, bias=False)
-        self.relu = nn.PReLU(num_parameters=1,init=0.2)
+        self.relu1 = nn.PReLU(num_parameters=1,init=0.2)
+        self.relu2 = nn.PReLU(num_parameters=1,init=0.2)
         self.conv2 = nn.Conv2d(in_channels=64, out_channels=64, kernel_size=3, stride=1, padding=1, bias=False)
         if bn:
             self.bn1 = nn.BatchNorm2d(64)
@@ -26,12 +27,13 @@ class _Residual_Block(nn.Module):
         output = self.conv1(x)
         if self.bn:
             output =self.bn1(output)
-        output = self.relu(output)
+        output = self.relu1(output)
         output = self.conv2(output)
         if self.bn:
             output = self.bn2(output)
         output = torch.add(output,x)
-        return output 
+        output = self.relu2(output)
+        return output
 
 class SRResNet(nn.Module):
     def __init__(self,in_channels = 3,out_channels = 3,bn = True):


### PR DESCRIPTION
Hi,

Great repo, it's a good starting point for SR in pytorch.

I think every "Residual Block" is missing an activation function at the end, at least according to the original ResNet paper: 
![image](https://user-images.githubusercontent.com/1676907/75176159-4fff3100-573c-11ea-9a94-8db242bdf9d9.png)
(from https://arxiv.org/abs/1512.03385)

it probably makes sense to add it since every other convolution currently basically does two consecutive convolutions in a row which isn't useful(?)